### PR TITLE
DateFormatter fix to display in current locale

### DIFF
--- a/Provisioning/GeneratePreviewForURL.m
+++ b/Provisioning/GeneratePreviewForURL.m
@@ -153,7 +153,8 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
 					id value = nil;
 					NSString *synthesizedValue = nil;
 					NSDateFormatter *dateFormatter = [NSDateFormatter new];
-					[dateFormatter setDateFormat:@"EEEE',' MMMM d',' yyyy 'at' h:mm a"];
+					[dateFormatter setDateStyle:NSDateFormatterMediumStyle];
+					[dateFormatter setTimeStyle:NSDateFormatterMediumStyle];
 					NSCalendar *calendar = [NSCalendar currentCalendar];
 					
 					value = [propertyList objectForKey:@"CreationDate"];


### PR DESCRIPTION
In Russian locale dates are too verbose: p.m. is expanded to "после полудня". Maybe time formatter should respect locale settings, so in Russia we can see 24-hour time?
![Russian locale example](https://f.cloud.github.com/assets/3132438/1881059/46503334-7962-11e3-9d0e-ef1ad78802ab.png)
